### PR TITLE
Missing a step

### DIFF
--- a/Lab1-MigrateYourData/README.md
+++ b/Lab1-MigrateYourData/README.md
@@ -152,9 +152,10 @@ First you need to do a migration assessment to ensure the database has no issues
 4. Select `Next`
 5. Enter 'localhost' for server name and Windows authentication
 6. UN-Check the Encrypt Connection Box
-7. Select the `TailwindInventory` database, select `Add`
-8. Select `Start Assessment`
-9. You will see a report on compatibility issues, and in a production environment you would now have a list of possible incompatibilities that would have to be addressed.
+7. Click `Connect`
+8. Select the `TailwindInventory` database, select `Add`
+9. Select `Start Assessment`
+10. You will see a report on compatibility issues, and in a production environment you would now have a list of possible incompatibilities that would have to be addressed.
 
 #### Schema Migration 
 


### PR DESCRIPTION
After telling us how to define the connection to the source database, you never tell us to click `Connect` at the bottom before selecting the source database. I've added the step to click Connect and renumbered all subsequent steps in that phase of the exercise. There are several other places where you tell us to choose our source database when it is the only one available and already selected. Same with select all tables. It was already selected.